### PR TITLE
Support formatting nginx.conf file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   ParserOptions,
   Printer,
   RequiredOptions,
+  SupportLanguage,
 } from "prettier";
 import { builders } from "prettier/doc";
 
@@ -82,9 +83,11 @@ export const languages = [
     name: "nginx",
     parsers: ["nginx"],
     extensions: [".nginx", ".nginxconf"],
+    filenames: ["nginx.conf"],
     linguistLanguageId: 248,
+    vscodeLanguageIds: ["nginx"],
   },
-];
+] satisfies SupportLanguage[];
 
 export const parsers: { [name: string]: Parser } = {
   nginx: {


### PR DESCRIPTION
Related to https://github.com/joedeandev/prettier-plugin-nginx/issues/5#issuecomment-1612077416, this PR adds support for formatting the `nginx.conf` file. I was able to build and test this in one of my local repos and saw it working, but I'd like to figure out how to add a test case for this.